### PR TITLE
fix: denobata start time

### DIFF
--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -11,9 +11,10 @@ const latest = (await getConnpassEvent())[0];
 const toDateStr = (date: Date) => {
   return format(date, "yyyy-MM-dd");
 };
-const toTimeStr = (date: Date) => {
-  return format(date, "HH:mm");
-};
+const toTimeStr = new Intl.DateTimeFormat("ja", {
+  timeZone: "Asia/Tokyo",
+  timeStyle: "short",
+});
 
 const remainDate = (date: Date) => {
   const diff = date.getTime() - new Date().getTime();
@@ -99,7 +100,7 @@ function Denobata() {
                   {remainStr(new Date(latest.started_at))}
                 </span>
                 <p class={tw`text-gray-500 mx-2 text-center`}>
-                  {toTimeStr(new Date(latest.started_at))}〜
+                  {toTimeStr.format(new Date(latest.started_at))}〜
                 </p>
               </div>
               <div class={tw`mt-4 text-center`}>


### PR DESCRIPTION
Denoばた会議の開始時刻を Asia/Tokyo time zone で表示する変更です

<img width="306" alt="スクリーンショット 2022-08-14 21 03 10" src="https://user-images.githubusercontent.com/613956/184535919-3ba5474e-a259-469d-8bf7-6f7a251f3bfa.png">