### PR TITLE
`<html lang="ja">` 設定にする

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -18,6 +18,7 @@ function render(ctx: RenderContext, render: InnerRenderFunction) {
   const snapshot = ctx.state.get("twind") as unknown[] | null;
   sheet.reset(snapshot || undefined);
   render();
+  ctx.lang = "ja";
   ctx.styles.splice(0, ctx.styles.length, ...(sheet).target);
   const newSnapshot = sheet.reset();
   ctx.state.set("twind", newSnapshot);


### PR DESCRIPTION
日本ユーザ向けサイトなので lang 指定を ja にしておきました（デフォルトは lang=en になっています）

<table>
  <tr>
    <th>変更前
    <th>変更後
  </tr>
  <tr>
    <td><img width="494" alt="スクリーンショット：html 要素の lang 属性値が en になっている" src="https://user-images.githubusercontent.com/1996642/184586294-d11ca10f-fbf8-4c31-aca0-005e7bdfd9d8.png">
    <td><img width="437" alt="スクリーンショット：html 要素の lang 属性値が ja に変わっている" src="https://user-images.githubusercontent.com/1996642/184586289-ed510662-be4f-43f5-8e3a-88e56bfb03f1.png">
  </tr>
</table>

ref: https://github.com/denoland/fresh/pull/288