### PR TITLE
abort fetch connpass API on timeout

### DIFF
--- a/routes/api/events.ts
+++ b/routes/api/events.ts
@@ -4,14 +4,26 @@ export interface ConnpassEvent {
   started_at?: string;
 }
 
+const timeout = 2000; // 2000ms
+
 export async function getConnpassEvent(): Promise<ConnpassEvent[]> {
   let json: any;
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort();
+  }, timeout);
   try {
-    json =
-      await (await fetch("https://connpass.com/api/v1/event/?series_id=7931"))
-        .json();
+    json = await (await fetch(
+      "https://connpass.com/api/v1/event/?series_id=7931",
+      {
+        signal: controller.signal,
+      },
+    ))
+      .json();
   } catch (_) {
     return [];
+  } finally {
+    clearTimeout(timer);
   }
   return json.events;
 }


### PR DESCRIPTION
* 2秒間connpassからResponseが返ってこなかったら[fetchをabort](https://blog.utgw.net/entry/2021/06/03/103006)するようにしました
  - 手元で試した感じ、大体300msでconnpassからResponseが返ってきていたので安全マージン取れてると思います
* abortした場合、 #6 の形式でデフォルトのイベント情報が返ります